### PR TITLE
support specifying a default type for .js files with no type in pkg json

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,12 @@ const defaultBuiltins = {
 }
 
 class ScriptLinker {
-  constructor ({ map = defaultMap, builtins = defaultBuiltins, linkSourceMaps = true, stat, readFile, isFile, isDirectory }) {
+  constructor ({ map = defaultMap, builtins = defaultBuiltins, linkSourceMaps = true, defaultType = 'commonjs', stat, readFile, isFile, isDirectory }) {
     this.map = map
     this.modules = new Map()
     this.builtins = builtins
     this.linkSourceMaps = linkSourceMaps
+    this.defaultType = defaultType
 
     this._userStat = stat || null
     this._userReadFile = readFile || null
@@ -62,7 +63,7 @@ class ScriptLinker {
     }
   }
 
-  async load (filename) {
+  async load (filename, opts) {
     let m = this.modules.get(filename)
 
     if (m) {
@@ -70,7 +71,7 @@ class ScriptLinker {
       return m
     }
 
-    m = new Mod(this, filename)
+    m = new Mod(this, filename, opts)
     this.modules.set(filename, m)
 
     try {

--- a/lib/module.js
+++ b/lib/module.js
@@ -8,10 +8,11 @@ const acorn = require('acorn')
 const sourceMap = require('source-map')
 
 module.exports = class JSModule {
-  constructor (linker, filename) {
+  constructor (linker, filename, { defaultType = linker.defaultType } = {}) {
     this.linker = linker
     this.filename = filename
     this.dirname = path.dirname(filename)
+    this.defaultType = defaultType
     this.builtin = false
     this.type = null
     this.package = null
@@ -198,7 +199,7 @@ module.exports = class JSModule {
 
     if (!type) {
       pkg = await this.linker.findPackageJSON(this.filename)
-      type = pkg && pkg.type === 'module' ? 'module' : 'commonjs'
+      type = pkg && pkg.type === 'module' ? 'module' : (pkg.type === 'commonjs' ? 'commonjs' : this.defaultType)
     }
 
     if (stat && stat.cache && this.cache === stat.cache && type === this.type) {


### PR DESCRIPTION
Defaults to commonjs (like node), but can be configured per load, so you can tweak the bootstrap module only if you wanted like in holepunch