### PR TITLE
ignore cjs module.exports.default property

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -142,6 +142,7 @@ module.exports = class JSModule {
 
     if (e) {
       for (const key of e.named) {
+        if (key === 'default') continue
         if (!isProperty(key)) continue
         out += `export const ${key} = typeof mod.${key} === 'function' ? mod.${key}.bind(mod) : mod.${key}\n`
       }


### PR DESCRIPTION
if a CJS module defines a `module.exports.default` property it's usually just a circular reference to `module.exports`. This is done by some modules to support rough edges around babel/webpack. 

We `default export module.exports` anyway, so the circular reference doesn't matter.

In cases where `module.exports.default` is some other value, that's for some reason important to the library, it couldn't be imported via named imports anyway `import { default } from 'mod'` would fail due to default being a reserved keyword. But since we `default export module.exports`, `import mod from 'mod'` could be used to then reference `mod.default`. 

Therefore, ignoring the default property when ESM wrapping makes most sense.