### PR TITLE
fix for faux esm cjs

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -95,21 +95,29 @@ module.exports = class Module {
     const e = this.exports
 
     let out = ''
-
+    let cjsHasDefaultKey = false
+    let __esModuleDetected = false
     out += 'const mod = ' + requireFromSource(this.linker._ns, this.filename, this.toCJS()) + '\n'
 
     if (e) {
       for (const key of e.named) {
-        if (key === 'default') continue
+        if (key === '__esModule') {
+          __esModuleDetected = true
+          continue
+        }
+        if (key === 'default') {
+          cjsHasDefaultKey = true
+          continue
+        }
         if (!isProperty(key)) continue
         out += `export const ${key} = typeof mod.${key} === 'function' ? mod.${key}.bind(mod) : mod.${key}\n`
       }
-      if (e.default) {
+      if (__esModuleDetected && cjsHasDefaultKey) {
+        out += 'export default typeof mod.default === \'function\' ? mod.default.bind(mod) : mod.default'
+      } else if (e.default) {
         out += 'export default mod\n'
       }
     }
-
-    out += '//# sourceURL=' + this.filename + '+esm-wrap'
 
     return out
   }


### PR DESCRIPTION
Bundlers use an `__esModule` property on a cjs module.exports to indicate that this is a cjs module representing ESM. In these situations the `default` property of the module.exports object is taken as the default export, and all other properties (excluding __esModule of course) are then named exports. 

Upstream is using such a module, and it fails here: https://github.com/hypercore-skunkworks/upstream/blob/main/lib/tiptap/list-item.js#L3

Because BaseListItem is an object with `{ ListItem, default: ListItem}` instead of `ListItem`. 
The module in question is https://www.npmjs.com/package/@tiptap/extension-list-item which doesn't have any dist code anywhere in its repo, so it's reproduced here:

```js
'use strict';

Object.defineProperty(exports, '__esModule', { value: true });

var core = require('@tiptap/core');

const ListItem = core.Node.create({
    name: 'listItem',
    addOptions() {
        return {
            HTMLAttributes: {},
        };
    },
    content: 'paragraph block*',
    defining: true,
    parseHTML() {
        return [
            {
                tag: 'li',
            },
        ];
    },
    renderHTML({ HTMLAttributes }) {
        return ['li', core.mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
    },
    addKeyboardShortcuts() {
        return {
            Enter: () => this.editor.commands.splitListItem(this.name),
            Tab: () => this.editor.commands.sinkListItem(this.name),
            'Shift-Tab': () => this.editor.commands.liftListItem(this.name),
        };
    },
});

exports.ListItem = ListItem;
exports["default"] = ListItem;
//# sourceMappingURL=tiptap-extension-list-item.cjs.js.map
```


This is a common pattern for compiling faux-esm/typescript to cjs. This PR looks for `__esModule` and `default` properties and then exports `mod.default` instead of `default` if they're found. We could play more loose and always export mod.default if it's there, but if we check for `__esModule` there's no ambiguity of what module.exports.default represents.

On a side note the package.json of `@tiptap/extension-list-item` contains a `module` field that points to transpiled esm. We support the package.json `exports` field instead, and arguably the web should be moving towards that instead of using the `module` field. So we could either continue to wrap CJS in where we have a main and a module field with compiled esm and wait for the ecosystem to catch up and use the `exports` field, or we could support the `module` field as well.







