### PR TITLE
use strict usage throws an error if the params are "non-simple" (!!!)…

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -37,9 +37,9 @@ module.exports = async function bundle (s, filename, { builtins } = {}) {
       out += '  ' + JSON.stringify(cjs[i].filename) + ': { exports: ' + e + ' }' + (i === 0 ? '' : ',') + '\n'
     }
     out += '}\n'
-    out += 'require.scope = function (map, fn) {\n'
+    out += 'require.scope = function (map, filename, dirname, module, fn) {\n'
     out += '  scopedRequire.cache = require.cache\n'
-    out += '  fn(scopedRequire)\n'
+    out += '  fn(scopedRequire, filename, dirname, module, )\n'
     out += '  function scopedRequire (req) {\n'
     out += '    if (!map.hasOwnProperty(req)) throw new Error("Cannot require \'" + req + "\'")\n'
     out += '    return require(map[req])\n'
@@ -49,10 +49,11 @@ module.exports = async function bundle (s, filename, { builtins } = {}) {
       const mod = cjs[i]
       if (mod.builtin) continue
       const map = mod.requireMap() || {}
-      out += 'require.scope(' + JSON.stringify(map) + ', function (require, '
-      out += '__filename = ' + JSON.stringify(mod.filename) + ', '
-      out += '__dirname = ' + JSON.stringify(mod.dirname) + ', '
-      out += 'module = require.cache[' + JSON.stringify(mod.filename) + ']) {\n'
+      out += 'require.scope(' + JSON.stringify(map) + ','
+      out += JSON.stringify(mod.filename) + ','
+      out += JSON.stringify(mod.dirname) + ','
+      out += require.cache[' + JSON.stringify(mod.filename) + '] + ','
+      out += 'function (require, __filename, __dirname, module) {'
       out += mod.toCJS()
       out += '})\n'
     }


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params