### PR TITLE
Use public ci runners

### DIFF
--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - public-ci
   pull_request:
     branches:
       - main
@@ -12,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version: [lts/*]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version: [lts/*]
-        os: [[self-hosted, Linux], [self-hosted, macOS]]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -19,8 +19,5 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        registry-url: 'https://npm.pkg.github.com'
     - run: npm install
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm test

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - public-ci
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Note: removed access to the github repo, as it has no dependencies there

Note: tested with a windows runner too, but that currently fails. 

```
node:internal/modules/esm/load:239
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:239:11)
    at defaultLoad (node:internal/modules/esm/load:130:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:409:13)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:56)
    at new ModuleJob (node:internal/modules/esm/module_job:65:26)
    at #createModuleJob (node:internal/modules/esm/loader:303:17)
    at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:260:34)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:241:17)
    at async ModuleLoader.import (node:internal/modules/esm/loader:328:23) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}

Node.js v20.11.0
Error: Process completed with exit code 1.
```