### PR TITLE
sourceTransform

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Options include:
   resolve: './module', // otherwise module is expressed by this request,
   dirname: '/', // resolve from the context of this dir
   transform: 'esm' || 'cjs' || 'map', // toESM(), toCJS() or generateSourceMap()?
+  sourceTransform: async function (buffer, filename) {}, // An async function to apply additional transforms to the file before parsing
 }
 ```
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -28,9 +28,9 @@ module.exports = class Module {
     this._reset = () => { this.refreshing = null }
   }
 
-  refresh () {
+  refresh (opts) {
     if (this.refreshing) return this.refreshing
-    this.refreshing = this._refresh().finally(this._reset)
+    this.refreshing = this._refresh(opts).finally(this._reset)
     return this.refreshing
   }
 
@@ -279,7 +279,7 @@ module.exports = class Module {
     }
   }
 
-  async _refresh () {
+  async _refresh (opts) {
     await parse.init()
 
     if (this.builtin) {
@@ -300,7 +300,7 @@ module.exports = class Module {
       return
     }
 
-    const source = b4a.toString(await this.linker._readFile(node, true))
+    const source = b4a.toString(await this.linker._readFile(node, true, opts))
     const cache = node && node.value && node.value.metadata
 
     const info = (cache && cache.type)


### PR DESCRIPTION
An optional sourceTransform function, allowing for custom transformations on source files (e.g., .jsx to .js) before they are parsed.
The addition of .jsx support to the sniffJS function, enabling .jsx files to be sniffed during the warmup process.